### PR TITLE
Request only a single path from Waze API

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -62,7 +62,7 @@ class WazeRouteCalculator(object):
             "returnGeometries": "true",
             "returnInstructions": "true",
             "timeout": 60000,
-            "nPaths": 3,
+            "nPaths": 1,
             "options": "AVOID_TRAILS:t",
         }
         response = requests.get(self.WAZE_URL + routing_req, params=url_options)


### PR DESCRIPTION
No need to download multiple ones, it only takes extra time and bandwidth