### PR TITLE
Add regions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,21 @@ import WazeRouteCalculator
 
 from_address = 'Budapest, Hungary'
 to_address = 'Gyor, Hungary'
-route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address)
+region = 'EU'
+route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region)
 route.calc_route_info()
 ```
 
 ```
-python example.py 
+python example.py
 From: Budapest, Hungary - to: Gyor, Hungary
 Time 69.27 minutes, distance 120.91 km.
 ```
+
+`from_address` and `to_address` are required. `region` is optional, and defaults to "EU". `region` can be one of:
+
+- EU (Europe)
+- US or NA (North America)
+- IL (Israel)
+
+The Waze API has separate URLs for each region, and so identifying the correct region is crucial.

--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -19,11 +19,16 @@ class WazeRouteCalculator(object):
 
     WAZE_URL = "https://www.waze.com/"
 
-    def __init__(self, start_address, end_address, log_lvl=logging.INFO):
+    def __init__(self, start_address, end_address, region='EU', log_lvl=logging.INFO):
         self.log = logging.getLogger(__name__)
         self.log.setLevel(log_lvl)
         self.log.addHandler(logging.StreamHandler())
         self.log.info("From: %s - to: %s", start_address, end_address)
+
+        region = region.upper()
+        if region == 'NA':  # North America
+            region = 'US'
+        self.region = region
 
         self.start_coords = self.address_to_coords(start_address)
         self.log.debug('Start coords: (%s, %s)', self.start_coords["lon"], self.start_coords["lat"])
@@ -33,13 +38,19 @@ class WazeRouteCalculator(object):
     def address_to_coords(self, address):
         """Convert address to coordinates"""
 
+        EU_BASE_COORDS = {"lon": 19.040, "lat": 47.498}
+        US_BASE_COORDS = {"lon": -74.006, "lat": 40.713}
+        IL_BASE_COORDS = {"lon": 35.214, "lat": 31.768}
+        BASE_COORDS = dict(US=US_BASE_COORDS, EU=EU_BASE_COORDS, IL=IL_BASE_COORDS)[self.region]
+        # the origin of the request can make a difference in the result
+
         get_cords = "SearchServer/mozi?"
         url_options = {
             "q": address,
             "lang": "eng",
             "origin": "livemap",
-            "lon": "19.040",
-            "lat": "47.498"
+            "lon": BASE_COORDS["lon"],
+            "lat": BASE_COORDS["lat"]
         }
         response = requests.get(self.WAZE_URL + get_cords, params=url_options)
         response_json = response.json()[0]
@@ -50,9 +61,10 @@ class WazeRouteCalculator(object):
     def get_route(self):
         """Get route data from waze"""
 
-        routing_req = "row-RoutingManager/routingRequest?"
-        # routing_req_us_canada = "RoutingManager/routingRequest"
-        # routing_req_israel = "il-RoutingManager/routingRequest"
+        routing_req_eu = "row-RoutingManager/routingRequest?"
+        routing_req_us_canada = "RoutingManager/routingRequest"
+        routing_req_israel = "il-RoutingManager/routingRequest"
+        routing_req = dict(US=routing_req_us_canada, EU=routing_req_eu, IL=routing_req_israel)[self.region]
 
         url_options = {
             "from": "x:%s y:%s" % (self.start_coords["lon"], self.start_coords["lat"]),

--- a/tests.py
+++ b/tests.py
@@ -60,6 +60,47 @@ class TestWRC():
         assert time == 2.00
         assert dist == 1.00
 
+    def test_get_route_eu(self):
+        self.routing_req = self.waze_url + "row-RoutingManager/routingRequest"
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "", "EU")
+            response = route.get_route()
+        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
+        assert self.routing_req in m.request_history[2].url
+
+    def test_get_route_us(self):
+        self.routing_req = self.waze_url + "RoutingManager/routingRequest"
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "", "US")
+            response = route.get_route()
+        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
+        assert self.routing_req in m.request_history[2].url
+
+    def test_get_route_na(self):
+        """NA (North America) is an alias for US (United States)"""
+        self.routing_req = self.waze_url + "RoutingManager/routingRequest"
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "", "na")
+            response = route.get_route()
+        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
+        assert self.routing_req in m.request_history[2].url
+
+    def test_get_route_il(self):
+        self.routing_req = self.waze_url + "il-RoutingManager/routingRequest"
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "", "il")
+            response = route.get_route()
+        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
+        assert self.routing_req in m.request_history[2].url
+
     def xtest_full_route_calc(self):
         from_address = 'From address'
         to_address = 'To address'


### PR DESCRIPTION
The Waze API has separate URLs for each region, and so identifying the correct region is crucial.
It was previously only working for European locations.