### PR TITLE
Add function to calculate multiple routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ From: Budapest, Hungary - to: Gyor, Hungary
 Time 69.27 minutes, distance 120.91 km.
 ```
 
+`calc_route_info` returns a tuple `(route_time, route_distance)` in addition to logging.
+
 `from_address` and `to_address` are required. `region` is optional, and defaults to "EU". `region` can be one of:
 
 - EU (Europe)
@@ -36,7 +38,30 @@ Time 69.27 minutes, distance 120.91 km.
 
 The Waze API has separate URLs for each region, and so identifying the correct region is crucial.
 
-### Silence logging
+### Multiple routes
+
+You can get multiple routes using the `route.calc_all_routes_info()` function:
+
+```python
+import WazeRouteCalculator
+
+from_address = 'Budapest, Hungary'
+to_address = 'Gyor, Hungary'
+region = 'EU'
+route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region)
+route.calc_all_routes_info()
+```
+
+```
+python example.py
+From: Budapest, Hungary - to: Gyor, Hungary
+Time 74.45 - 129.43 minutes, distance 120.91 - 130.08 km.
+```
+
+`calc_all_routes_info` takes an optional single parameter, the number of routes to fetch. Note that the Waze API may not return as many possibilities as requested. The function returns a dict: `{'route_name1': (route_time1, route_distance1), 'route_name2': (route_time2, route_distance2), ...}`.
+
+
+## Silence logging
 Pass `log_lvl=None` to silence output and just get the return value:
 
 ```python

--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,7 @@
 import WazeRouteCalculator as wrc
 import mock
 import requests_mock
-import StringIO
+# import StringIO
 
 
 class TestWRC():
@@ -29,36 +29,6 @@ class TestWRC():
             coords = route.address_to_coords(test_address)
         assert coords == {'lat': self.lat, 'lon': self.lon}
         assert m.call_count == 3
-
-    def test_get_route(self):
-        with requests_mock.mock() as m:
-            m.get(self.address_req, text=self.address_to_coords_response)
-            m.get(self.routing_req, text=self.routing_response)
-            route = wrc.WazeRouteCalculator("", "")
-            response = route.get_route()
-        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
-        assert self.routing_req in m.request_history[2].url
-
-    def test_get_best_route(self):
-        self.routing_response = '{"alternatives":[{"response":{"results":[{"length":%s,"crossTime":%s}]}}]}' % (self.length, self.time)
-        with requests_mock.mock() as m:
-            m.get(self.address_req, text=self.address_to_coords_response)
-            m.get(self.routing_req, text=self.routing_response)
-            route = wrc.WazeRouteCalculator("", "")
-            response = route.get_route()
-        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
-        assert self.routing_req in m.request_history[2].url
-
-    def test_calc_route_info(self):
-        with requests_mock.mock() as m:
-            m.get(self.address_req, text=self.address_to_coords_response)
-            route = wrc.WazeRouteCalculator("", "")
-        route_mock = mock.Mock(return_value={"results": [{"length": 1000, "crossTime": 120}]})
-        route.get_route = route_mock
-        time, dist = route.calc_route_info()
-        assert route_mock.called
-        assert time == 2.00
-        assert dist == 1.00
 
     def test_get_route_eu(self):
         self.routing_req = self.waze_url + "row-RoutingManager/routingRequest"
@@ -100,6 +70,75 @@ class TestWRC():
             response = route.get_route()
         assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
         assert self.routing_req in m.request_history[2].url
+
+    def test_get_route(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "")
+            response = route.get_route()
+        assert response == {"results": [{"length": self.length, "crossTime": self.time}]}
+        assert self.routing_req in m.request_history[2].url
+
+    def test_get_all_routes(self):
+        length2, time2 = (410, 62)
+        self.routing_response = '{"alternatives":[{"response":{"results":[{"length":%s,"crossTime":%s}]}},{"response":{"results":[{"length":%s,"crossTime":%s}]}}]}' % (self.length, self.time, length2, time2)
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "")
+            response = route.get_route(3)
+        assert response == [{"results": [{"length": self.length, "crossTime": self.time}]}, {"results": [{"length": length2, "crossTime": time2}]}]
+        assert self.routing_req in m.request_history[2].url
+
+    def test_get_route_only_one(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator("", "")
+            response = route.get_route(3)
+        assert response == [{"results": [{"length": self.length, "crossTime": self.time}]}]
+        assert self.routing_req in m.request_history[2].url
+
+    def test_add_up_route(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            route = wrc.WazeRouteCalculator("", "")
+        results = [{"length": 1000, "crossTime": 120}, {"length": 1000, "crossTime": 120}]
+        time, dist = route._add_up_route(results)
+        assert time == 4.00
+        assert dist == 2.00
+
+    def test_calc_route_info(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            route = wrc.WazeRouteCalculator("", "")
+        route_mock = mock.Mock(return_value={"results": [{"length": 1000, "crossTime": 120}]})
+        route.get_route = route_mock
+        time, dist = route.calc_route_info()
+        assert route_mock.called
+        assert time == 2.00
+        assert dist == 1.00
+
+    def test_calc_all_routes_info(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            route = wrc.WazeRouteCalculator("", "")
+        route_mock = mock.Mock(return_value=[{"routeName": "1", "results": [{"length": 1000, "crossTime": 120}]}, {"routeName": "2", "results": [{"length": 1100, "crossTime": 150}]}])
+        route.get_route = route_mock
+        results = route.calc_all_routes_info()
+        assert route_mock.called
+        assert results == {"1": (2.0, 1.0), "2": (2.5, 1.1)}
+
+    def test_calc_all_routes_info_only_one(self):
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            route = wrc.WazeRouteCalculator("", "")
+        route_mock = mock.Mock(return_value=[{"routeName": "1", "results": [{"length": 1000, "crossTime": 120}]}])
+        route.get_route = route_mock
+        results = route.calc_all_routes_info()
+        assert route_mock.called
+        assert results == {"1": (2.0, 1.0)}
 
     def xtest_full_route_calc(self):
         from_address = 'From address'


### PR DESCRIPTION
Make the `calc_route_info` function fetch only one route from the Waze API.

Add a function `calc_all_routes_info` that returns a dict with all the routes.

Tested in Python 2 and 3.

