### PR TITLE
Encode route names in UTF-8

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -92,6 +92,7 @@ class WazeRouteCalculator(object):
         }
 
         response = requests.get(self.WAZE_URL + routing_req, params=url_options, headers=headers)
+        response.encoding = 'utf-8'
         response_json = response.json()
         if response_json.get("error"):
             raise WRCError(response_json.get("error"))


### PR DESCRIPTION
Please encode the response to UTF-8.

Before:
![before](https://user-images.githubusercontent.com/15639616/42265799-dc887d4e-7f74-11e8-966c-6520e1030116.png)

After:
![after](https://user-images.githubusercontent.com/15639616/42265811-e5938ed8-7f74-11e8-9bc2-aeff2a1faa36.png)
 