### PR TITLE
Fix Empty response error.

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -144,7 +144,7 @@ class WazeRouteCalculator(object):
                     return [response_json['response']]
                 return response_json['response']
         else:
-            raise WRCError("Empty Response")
+            raise WRCError("empty response")
 
     @staticmethod
     def _check_response(response):

--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -34,6 +34,12 @@ class WazeRouteCalculator(object):
         'IL': 'il-SearchServer/mozi',
         'AU': 'row-SearchServer/mozi'
     }
+    ROUTING_SERVERS = {
+        'US': 'RoutingManager/routingRequest',
+        'EU': 'row-RoutingManager/routingRequest',
+        'IL': 'il-RoutingManager/routingRequest',
+        'AU': 'row-RoutingManager/routingRequest' 
+    }
     COORD_MATCH = re.compile('^([-+]?)([\d]{1,2})(((\.)(\d+)(,)))(\s*)(([-+]?)([\d]{1,3})((\.)(\d+))?)$')
 
     def __init__(self, start_address, end_address, region='EU', vehicle_type='', log_lvl=logging.INFO):
@@ -109,9 +115,8 @@ class WazeRouteCalculator(object):
     def get_route(self, npaths=1, time_delta=0):
         """Get route data from waze"""
 
-        routing_servers = ["row-RoutingManager/routingRequest",
-                           "RoutingManager/routingRequest",
-                           "il-RoutingManager/routingRequest"]
+        routing_server = self.ROUTING_SERVERS[self.region]
+
         url_options = {
             "from": "x:%s y:%s" % (self.start_coords["lon"], self.start_coords["lat"]),
             "to": "x:%s y:%s" % (self.end_coords["lon"], self.end_coords["lat"]),
@@ -126,20 +131,20 @@ class WazeRouteCalculator(object):
         if self.vehicle_type:
             url_options["vehicleType"] = self.vehicle_type
 
-        for routing_srv in routing_servers:
-            response = requests.get(self.WAZE_URL + routing_srv, params=url_options, headers=self.HEADERS)
-            response.encoding = 'utf-8'
-            response_json = self._check_response(response)
-            if response_json and 'error' not in response_json:
+        response = requests.get(self.WAZE_URL + routing_server, params=url_options, headers=self.HEADERS)
+        response.encoding = 'utf-8'
+        response_json = self._check_response(response)
+        if response_json:
+            if 'error' in response_json:
+                raise WRCError(response_json.get("error"))
+            else:
                 if response_json.get("alternatives"):
                     return [alt['response'] for alt in response_json['alternatives']]
                 if npaths > 1:
                     return [response_json['response']]
                 return response_json['response']
-        if response_json and 'error' not in response_json:
-            raise WRCError(response_json.get("error"))
         else:
-            raise WRCError("empty response")
+            raise WRCError("Empty Response")
 
     @staticmethod
     def _check_response(response):

--- a/tests.py
+++ b/tests.py
@@ -77,9 +77,9 @@ class TestWRC():
         assert self.routing_req in m.request_history[2].url
 
     def test_get_route_next_server(self):
-        fail_routing_req = self.waze_url + "row-RoutingManager/routingRequest"
+        fail_routing_req = self.waze_url + "RoutingManager/routingRequest"
         fail_routing_response = '{}'
-        ok_routing_req = self.waze_url + "RoutingManager/routingRequest"
+        ok_routing_req = self.waze_url + "row-RoutingManager/routingRequest"
         ok_routing_response = '{"response":{"results":[{"length":%s,"crossTime":%s}]}}' % (self.length, self.time)
         with requests_mock.mock() as m:
             m.get(self.address_req, text=self.address_to_coords_response)


### PR DESCRIPTION
So alot of users with home assistant have been reporting errors coming from WazeRouteCalculator.  These errors are essentially emtpy response or Internal Error which come directly from waze.  I've tracked the error down to one simple fact.  If you make a route request to the wrong server first, the subsequent requests get ignored or also fail.  This must be new to the API because it wasn't always like this.  So the fix is the use location based routing server requests.  Similar to how the COORD_SERVERS work.

I tested this in a build of home assistant with 11 separate routes.  3 in US using PRIVATE, TAXI, and MOTORCYCLE, 3 in EU using PRIVATE, TAXI, and MOTORCYCLE, 3 in IL using PRIVATE, TAXI, and MOTORCYCLE, and 2 others in IL and EU (random ones just for testing home assistant settings).  In this test calculate_all_routes getting performed twice a minute for a maximum of 1320 requests per hour. 

Prior to PR, roughly 776 errors per hour.

After PR, roughly ~~124~~ errors per hour.  124 errors was my mistake, searching for an IL route inside the EU.  After fixing that on my end the errors went down to roughly **0** inside an hour with requests being made every 30 seconds.

The current ~~124~~ errors seem to plague Taxi routes in EU and Motorcycle routes in IL.  I'm not 100% sure what is causing that problem.  However, the private routes had about 4 errors for the hour among the 4 routes.