### PR TITLE
Add options to avoid tolls and/or ferries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,38 @@ From: Budapest, Hungary - to: Gyor, Hungary
 Time 112.92 minutes, distance 124.93 km.
 ```
 
+### Avoid toll roads
+
+`avoid_toll_roads` is also optional, and defaults to False. Setting `avoid_toll_roads` to True
+will only return results not on a tollway.
+
+```python
+import WazeRouteCalculator
+
+from_address = 'Chicago, Illinois'
+to_address = 'New York City, New York'
+region = 'US'
+route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region, avoid_toll_roads=True)
+route.calc_route_info()
+```
+
+### Avoid ferries
+
+`avoid_ferries` is also optional, and defaults to False. Setting `avoid_ferries` to True
+will only return results not involving a ferry.
+
+```python
+import WazeRouteCalculator
+
+from_address = 'Long Branch, New Jersey'
+to_address = 'New York City, New York'
+region = 'US'
+route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region, avoid_ferries=True)
+route.calc_route_info()
+```
+
+
+
 ### Multiple routes
 
 You can get multiple routes using the `route.calc_all_routes_info()` function:

--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -42,7 +42,7 @@ class WazeRouteCalculator(object):
     }
     COORD_MATCH = re.compile('^([-+]?)([\d]{1,2})(((\.)(\d+)(,)))(\s*)(([-+]?)([\d]{1,3})((\.)(\d+))?)$')
 
-    def __init__(self, start_address, end_address, region='EU', vehicle_type='', log_lvl=logging.INFO):
+    def __init__(self, start_address, end_address, region='EU', vehicle_type='', route_options=None, avoid_toll_roads=False, avoid_ferries=False, log_lvl=logging.INFO):
         self.log = logging.getLogger(__name__)
         if log_lvl is None:
             log_lvl = logging.WARNING
@@ -59,6 +59,12 @@ class WazeRouteCalculator(object):
         self.vehicle_type = ''
         if vehicle_type and vehicle_type in self.VEHICLE_TYPES:
             self.vehicle_type = vehicle_type.upper()
+
+        self.route_options = ['AVOID_TRAILS']
+        if avoid_toll_roads:
+            self.route_options.append('AVOID_TOLL_ROADS')
+        if avoid_ferries:
+            self.route_options.append('AVOID_FERRIES')
 
         if self.already_coords(start_address): #See if we have coordinates or address to resolve
             self.start_coords = self.coords_string_parser(start_address)
@@ -126,7 +132,7 @@ class WazeRouteCalculator(object):
             "returnInstructions": "true",
             "timeout": 60000,
             "nPaths": npaths,
-            "options": "AVOID_TRAILS:t",
+            "options": ','.join('%s:t' % route_option for route_option in self.route_options),
         }
         if self.vehicle_type:
             url_options["vehicleType"] = self.vehicle_type

--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -42,7 +42,7 @@ class WazeRouteCalculator(object):
     }
     COORD_MATCH = re.compile('^([-+]?)([\d]{1,2})(((\.)(\d+)(,)))(\s*)(([-+]?)([\d]{1,3})((\.)(\d+))?)$')
 
-    def __init__(self, start_address, end_address, region='EU', vehicle_type='', route_options=None, avoid_toll_roads=False, avoid_ferries=False, log_lvl=logging.INFO):
+    def __init__(self, start_address, end_address, region='EU', vehicle_type='', avoid_toll_roads=False, avoid_ferries=False, log_lvl=logging.INFO):
         self.log = logging.getLogger(__name__)
         if log_lvl is None:
             log_lvl = logging.WARNING

--- a/tests.py
+++ b/tests.py
@@ -374,3 +374,63 @@ class TestWRC():
             route = wrc.WazeRouteCalculator(from_address, to_address)
             route.get_route()
         assert 'vehicletype' not in req.last_request.query
+
+    def test_avoid_toll_road_true(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=True)
+            route.get_route()
+        assert 'avoid_toll_roads' in req.last_request.query
+
+    def test_avoid_toll_road_false(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=False)
+            route.get_route()
+        assert 'avoid_toll_roads' not in req.last_request.query
+
+    def test_avoid_toll_road_not_changed(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=False)
+            route.get_route()
+        assert 'avoid_toll_roads' not in req.last_request.query
+
+    def test_avoid_ferries_true(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_ferries=True)
+            route.get_route()
+        assert 'avoid_ferries' in req.last_request.query
+
+    def test_avoid_ferries_false(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_ferries=False)
+            route.get_route()
+        assert 'avoid_ferries' not in req.last_request.query
+
+    def test_avoid_ferries_not_changed(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_ferries=False)
+            route.get_route()
+        assert 'avoid_ferries' not in req.last_request.query


### PR DESCRIPTION
  - Utilizes optional route items to configure trip settings
    - AVOID_TOLL_ROADS
      - Default: False
      - Prevents results being returned that utilize a tollway on the route
    - AVOID_FERRIES
      - Default: False
      - Prevents results being returned that utilize a ferry on the route