### PR TITLE
Added subscription url_option for vignette system in Europe

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -137,9 +137,7 @@ class WazeRouteCalculator(object):
         if self.vehicle_type:
             url_options["vehicleType"] = self.vehicle_type
         # Handle vignette system in Europe
-        if 'AVOID_TOLL_ROADS' in self.route_options:
-            pass #don't want to do anything if we're avoiding toll roads
-        else:
+        if 'AVOID_TOLL_ROADS' not in self.route_options:
             url_options["subscription"] = "*"
             
         response = requests.get(self.WAZE_URL + routing_server, params=url_options, headers=self.HEADERS)

--- a/tests.py
+++ b/tests.py
@@ -434,3 +434,23 @@ class TestWRC():
             route = wrc.WazeRouteCalculator(from_address, to_address, avoid_ferries=False)
             route.get_route()
         assert 'avoid_ferries' not in req.last_request.query
+    
+    def test_avoid_toll_road_true_vignette(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=True)
+            route.get_route()
+        assert 'subscription' in req.last_request.query
+
+    def test_avoid_toll_road_false_vignette(self):
+        from_address = 'From address'
+        to_address = 'To address'
+        with requests_mock.mock() as m:
+            m.get(self.address_req, text=self.address_to_coords_response)
+            req = m.get(self.routing_req, text=self.routing_response)
+            route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=False)
+            route.get_route()
+        assert 'subscription' not in req.last_request.query

--- a/tests.py
+++ b/tests.py
@@ -443,7 +443,7 @@ class TestWRC():
             req = m.get(self.routing_req, text=self.routing_response)
             route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=True)
             route.get_route()
-        assert 'subscription' in req.last_request.query
+        assert 'subscription' not in req.last_request.query
 
     def test_avoid_toll_road_false_vignette(self):
         from_address = 'From address'
@@ -453,4 +453,4 @@ class TestWRC():
             req = m.get(self.routing_req, text=self.routing_response)
             route = wrc.WazeRouteCalculator(from_address, to_address, avoid_toll_roads=False)
             route.get_route()
-        assert 'subscription' not in req.last_request.query
+        assert 'subscription' in req.last_request.query


### PR DESCRIPTION
Added subscription url_option for vignette system in Europe
When avoid_toll_roads is set, we don't need anything, but if it isn't, we need to add a url_option which specifies we have all vignettes (or toll-pass stickers).
The possibility to replace subscription=* with one or more subscription=vignette-country url_options is there for the future, but for now, allowing all is what I needed.