### PR TITLE
fix new format error

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -143,9 +143,12 @@ class WazeRouteCalculator(object):
             else:
                 if response_json.get("alternatives"):
                     return [alt['response'] for alt in response_json['alternatives']]
+                response_obj = response_json['response']
                 if npaths > 1:
-                    return [response_json['response']]
-                return response_json['response']
+                    return [response_obj]
+                if isinstance(response_obj, list):
+                    response_obj = response_obj[0]
+                return response_obj
         else:
             raise WRCError("empty response")
 
@@ -181,7 +184,10 @@ class WazeRouteCalculator(object):
                     between(y, end_bounds.get('bottom', 0), end_bounds.get('top', 0))
                 ):
                     continue
-            time += segment['crossTime' if real_time else 'crossTimeWithoutRealTime']
+            if 'crossTime' in segment:
+                time += segment['crossTime' if real_time else 'crossTimeWithoutRealTime']
+            else:
+                time += segment['cross_time' if real_time else 'cross_time_without_real_time']
             distance += segment['length']
         route_time = time / 60.0
         route_distance = distance / 1000.0
@@ -191,7 +197,7 @@ class WazeRouteCalculator(object):
         """Calculate best route info."""
 
         route = self.get_route(1, time_delta)
-        results = route['results']
+        results = route['results'] if 'results' in route else route['result']
         route_time, route_distance = self._add_up_route(results, real_time=real_time, stop_at_bounds=stop_at_bounds)
         self.log.info('Time %.2f minutes, distance %.2f km.', route_time, route_distance)
         return route_time, route_distance

--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -144,10 +144,10 @@ class WazeRouteCalculator(object):
                 if response_json.get("alternatives"):
                     return [alt['response'] for alt in response_json['alternatives']]
                 response_obj = response_json['response']
-                if npaths > 1:
-                    return [response_obj]
                 if isinstance(response_obj, list):
                     response_obj = response_obj[0]
+                if npaths > 1:
+                    return [response_obj]
                 return response_obj
         else:
             raise WRCError("empty response")
@@ -197,7 +197,7 @@ class WazeRouteCalculator(object):
         """Calculate best route info."""
 
         route = self.get_route(1, time_delta)
-        results = route['results'] if 'results' in route else route['result']
+        results = route['results' if 'results' in route else 'result']
         route_time, route_distance = self._add_up_route(results, real_time=real_time, stop_at_bounds=stop_at_bounds)
         self.log.info('Time %.2f minutes, distance %.2f km.', route_time, route_distance)
         return route_time, route_distance
@@ -206,7 +206,7 @@ class WazeRouteCalculator(object):
         """Calculate all route infos."""
 
         routes = self.get_route(npaths, time_delta)
-        results = {route['routeName']: self._add_up_route(route['results'], real_time=real_time, stop_at_bounds=stop_at_bounds) for route in routes}
+        results = {route['routeName' if 'routeName' in route else 'route_name']: self._add_up_route(route['results' if 'results' in route else 'result'], real_time=real_time, stop_at_bounds=stop_at_bounds) for route in routes}
         route_time = [route[0] for route in results.values()]
         route_distance = [route[1] for route in results.values()]
         self.log.info('Time %.2f - %.2f minutes, distance %.2f - %.2f km.', min(route_time), max(route_time), min(route_distance), max(route_distance))


### PR DESCRIPTION
Running the following script

```python
import WazeRouteCalculator
import logging

logger = logging.getLogger('WazeRouteCalculator.WazeRouteCalculator')
logger.setLevel(logging.DEBUG)
handler = logging.StreamHandler()
logger.addHandler(handler)

from_address = 'Budapest, Hungary'
to_address = 'Gyor, Hungary'
region = 'EU'
route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region)
route.calc_route_info()
route.calc_all_routes_info()

from_address = 'שדרות המגנים 24, חיפה'
to_address = 'ירושלים 18, חיפה'
region = 'IL'
route = WazeRouteCalculator.WazeRouteCalculator(from_address, to_address, region)
route.calc_route_info()
route.calc_all_routes_info()
```

Yields the following error:
```
 WazeRouteCalculator(origin, destination, region).calc_all_routes_info()
  File "/usr/local/lib/python3.9/site-packages/WazeRouteCalculator/WazeRouteCalculator.py", line 203, in calc_all_routes_info
    results = {route['routeName']: self._add_up_route(route['results'], real_time=real_time, stop_at_bounds=stop_at_bounds) for route in routes}
  File "/usr/local/lib/python3.9/site-packages/WazeRouteCalculator/WazeRouteCalculator.py", line 203, in <dictcomp>
    results = {route['routeName']: self._add_up_route(route['results'], real_time=real_time, stop_at_bounds=stop_at_bounds) for route in routes}
TypeError: list indices must be integers or slices, not str
```

It seems that the API sometimes returns a new format for the IL region. This PR handles that new format